### PR TITLE
feat: upgrade TypeScript to 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.tgz
+.cache/
 .env
 .idea
 .vscode/
@@ -7,6 +8,5 @@
 build/
 dist/
 node_modules/
-.cache/
 tsconfig.tsbuildinfo
-package-lock.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 node_modules/
 .cache/
 tsconfig.tsbuildinfo
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"sort-package-json": "^3.6.1",
 		"tsx": "^4.22.4",
 		"type-fest": "^5.7.0",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.8"
 	},
 	"packageManager": "yarn@4.13.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,7 +105,10 @@
 		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
 		/* Language and Environment */
-		"target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+		"target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"types": [
+			"node"
+		] /* TypeScript 6.0 changed the default from auto-discovering all @types packages to an empty array. */
 	},
 	"exclude": ["src/**/*.test.ts"],
 	"include": ["src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,9 +106,7 @@
 
 		/* Language and Environment */
 		"target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-		"types": [
-			"node"
-		] /* TypeScript 6.0 changed the default from auto-discovering all @types packages to an empty array. */
+		"types": ["node"]
 	},
 	"exclude": ["src/**/*.test.ts"],
 	"include": ["src/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,7 +1330,7 @@ __metadata:
     ts-pattern: "npm:^5.9.0"
     tsx: "npm:^4.22.4"
     type-fest: "npm:^5.7.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.8"
     xstate: "npm:^5.32.0"
   bin:
@@ -2498,23 +2498,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TypeScript 6.0 changed the default for `types` from auto-discovering all
@types packages to an empty array. Adds `"types": ["node"]` to tsconfig
so that @types/node is resolved for node: imports.

https://claude.ai/code/session_01D4You5fUSopfnKhLBBtqBA